### PR TITLE
Fix parser and add modulo operator

### DIFF
--- a/bytecode.h
+++ b/bytecode.h
@@ -15,6 +15,7 @@ typedef enum {
     OP_SUB,
     OP_MUL,
     OP_DIV,
+    OP_MOD,
     OP_GT,
     OP_LT,
     OP_GTE,

--- a/compiler.c
+++ b/compiler.c
@@ -102,6 +102,7 @@ static void compile_expression(ASTNode *expr, Bytecode *bc) {
                 case T_MINUS: emit_byte(bc, OP_SUB); break;
                 case T_STAR:  emit_byte(bc, OP_MUL); break;
                 case T_SLASH: emit_byte(bc, OP_DIV); break;
+                case T_MOD:   emit_byte(bc, OP_MOD); break;
                 case T_GT:    emit_byte(bc, OP_GT);  break;
                 case T_LT:    emit_byte(bc, OP_LT);  break;
                 case T_GTE:   emit_byte(bc, OP_GTE); break;

--- a/lexer.c
+++ b/lexer.c
@@ -71,6 +71,7 @@ Token *lex(const char *source, size_t *out_count) {
             case '-': add_token(&tokens,&count,&capacity,T_MINUS,NULL,line,tok_col); i++;col++;break;
             case '*': add_token(&tokens,&count,&capacity,T_STAR,NULL,line,tok_col); i++;col++;break;
             case '/': add_token(&tokens,&count,&capacity,T_SLASH,NULL,line,tok_col); i++;col++;break;
+            case '%': add_token(&tokens,&count,&capacity,T_MOD,NULL,line,tok_col); i++;col++;break;
             case '>':
                 if (source[i+1]=='=') { add_token(&tokens,&count,&capacity,T_GTE,NULL,line,tok_col); i+=2; col+=2; }
                 else { add_token(&tokens,&count,&capacity,T_GT,NULL,line,tok_col); i++;col++; }

--- a/parser.c
+++ b/parser.c
@@ -33,7 +33,7 @@ static void expect(Parser *p, TokenType tt, const char *msg) {
 }
 static int get_prec(TokenType op) {
     switch (op) {
-        case T_STAR: case T_SLASH: return 3;
+        case T_STAR: case T_SLASH: case T_MOD: return 3;
         case T_PLUS: case T_MINUS: return 2;
         case T_GT: case T_LT: case T_GTE:
         case T_LTE: case T_EQ: case T_NEQ: return 1;
@@ -68,7 +68,6 @@ static ASTNode *parse_program(Parser *p) {
                 } while(match(p, T_COMMA));
                 expect(p, T_RPAREN, "Expected ')' after params");
             }
-            expect(p, T_LBRACE, "Expected '{' before function body");
             ASTNode *body = parse_block(p);
             ASTNode *fn = ast_node_new(AST_FUNCTION, name->line, name->column);
             fn->as.func_def.name = strdup(name->text);
@@ -121,16 +120,16 @@ static ASTNode *parse_statement(Parser *p) {
         n->as.return_stmt.value = val;
         return n;
     }
-    if (t->type == T_IDENTIFIER && t->text[0]=='$') {
-        Token *name = advance(p);
-        if (match(p, T_ASSIGN)) {
-            ASTNode *v = parse_expression(p, 0);
-            expect(p, T_SEMICOLON, "Expected ';' after assignment");
-            ASTNode *n = ast_node_new(AST_VAR_ASSIGN, name->line, name->column);
-            n->as.var_assign.name = strdup(name->text);
-            n->as.var_assign.value = v;
-            return n;
-        }
+    if (t->type == T_IDENTIFIER && t->text[0]=='$' &&
+        p->pos + 1 < p->count && p->tokens[p->pos + 1].type == T_ASSIGN) {
+        Token *name = advance(p); // consume identifier
+        advance(p); // consume '='
+        ASTNode *v = parse_expression(p, 0);
+        expect(p, T_SEMICOLON, "Expected ';' after assignment");
+        ASTNode *n = ast_node_new(AST_VAR_ASSIGN, name->line, name->column);
+        n->as.var_assign.name = strdup(name->text);
+        n->as.var_assign.value = v;
+        return n;
     }
     ASTNode *expr = parse_expression(p, 0);
     expect(p, T_SEMICOLON, "Expected ';' after expression");
@@ -156,7 +155,8 @@ static ASTNode *parse_primary(Parser *p) {
         n->as.literal.value = atoi(t->text);
         return n;
     }
-    if (match(p, T_IDENTIFIER)) {
+    if (t->type == T_IDENTIFIER || t->type == T_PRINT) {
+        advance(p);
         if (peek(p)->type==T_LPAREN) {
             char *name=strdup(t->text);
             advance(p);
@@ -177,7 +177,6 @@ static ASTNode *parse_primary(Parser *p) {
         }
         ASTNode *n = ast_node_new(AST_VAR_REF, t->line, t->column);
         n->as.var_ref.name = strdup(t->text);
-        advance(p);
         return n;
     }
     if (match(p, T_LPAREN)) {
@@ -194,7 +193,7 @@ static ASTNode *parse_expression(Parser *p, int min_prec) {
     while (1) {
         Token *t = peek(p);
         int prec = get_prec(t->type);
-        if (prec < min_prec) break;
+        if (prec == 0 || prec < min_prec) break;
         TokenType op = t->type;
         advance(p);
         ASTNode *rhs = parse_expression(p, prec+1);

--- a/tokens.h
+++ b/tokens.h
@@ -33,6 +33,7 @@ typedef enum {
     T_MINUS,    // -
     T_STAR,     // *
     T_SLASH,    // /
+    T_MOD,      // %
     T_ASSIGN,   // =
     T_GT,       // >
     T_LT,       // <

--- a/vm.c
+++ b/vm.c
@@ -66,6 +66,7 @@ int run_bytecode(const Bytecode *bc) {
             case OP_SUB:    { int b=pop_(&vm), a=pop_(&vm); push(&vm, a-b); break; }
             case OP_MUL:    { int b=pop_(&vm), a=pop_(&vm); push(&vm, a*b); break; }
             case OP_DIV:    { int b=pop_(&vm), a=pop_(&vm); push(&vm, a/b); break; }
+            case OP_MOD:    { int b=pop_(&vm), a=pop_(&vm); push(&vm, a%b); break; }
             case OP_GT:     { int b=pop_(&vm), a=pop_(&vm); push(&vm, a>b); break; }
             case OP_LT:     { int b=pop_(&vm), a=pop_(&vm); push(&vm, a<b); break; }
             case OP_GTE:    { int b=pop_(&vm), a=pop_(&vm); push(&vm, a>=b); break; }


### PR DESCRIPTION
## Summary
- correct operator precedence loop break condition in parser
- treat `print` like an identifier so calls parse correctly
- parse assignments only when followed by '='
- add `%` operator support across lexer, parser, compiler, VM

## Testing
- `make`
- `./bin/phpc tests/example.phpc`

------
https://chatgpt.com/codex/tasks/task_e_6878c7617944832290143fb6062a5d5b