### PR TITLE
Add string literal support

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -75,6 +75,9 @@ void free_ast(ASTNode *node) {
             free_ast(node->as.binary.right);
             break;
         case AST_LITERAL:
+            if (node->as.literal.is_string) {
+                free(node->as.literal.str);
+            }
             break;
         case AST_VAR_REF:
             free(node->as.var_ref.name);

--- a/ast.h
+++ b/ast.h
@@ -38,7 +38,7 @@ typedef struct ASTNode {
         struct { char *name; char **params; size_t param_count; struct ASTNode *body; } func_def;
         struct { ASTNodeList *statements; } block;
         struct { TokenType op; struct ASTNode *left, *right; } binary;
-        struct { int value; } literal;
+        struct { int is_string; int value; char *str; } literal;
         struct { char *name; } var_ref;
         struct { char *name; struct ASTNode **args; size_t arg_count; } func_call;
     } as;

--- a/bytecode.c
+++ b/bytecode.c
@@ -13,10 +13,15 @@ Bytecode *bytecode_new(void) {
 
 void bytecode_free(Bytecode *bc) {
     free(bc->code);
+    for (size_t i = 0; i < bc->const_count; i++) {
+        if (bc->constants[i].type == VAL_STR) {
+            free(bc->constants[i].str_val);
+        }
+    }
     free(bc);
 }
 
-int bytecode_new_constant(Bytecode *bc, int value) {
+int bytecode_new_constant(Bytecode *bc, Value value) {
     if (bc->const_count >= MAX_CONSTANTS) {
        fprintf(stderr, "Too many constants");
         exit(EXIT_FAILURE);

--- a/bytecode.h
+++ b/bytecode.h
@@ -5,7 +5,15 @@
 #include <stdint.h>
 #include <stddef.h> // size_t
 
+
 #define MAX_CONSTANTS 256
+
+typedef enum { VAL_INT, VAL_STR } ValueType;
+
+typedef struct {
+    ValueType type;
+    union { int int_val; char *str_val; };
+} Value;
 
 typedef enum {
     OP_CONSTANT,
@@ -33,13 +41,13 @@ typedef enum {
 typedef struct {
     uint8_t *code;
     size_t code_size;
-    int constants[MAX_CONSTANTS];
+    Value constants[MAX_CONSTANTS];
     size_t const_count;
 } Bytecode;
 
 Bytecode *bytecode_new(void);
 void bytecode_free(Bytecode *bc);
-int bytecode_new_constant(Bytecode *bc, int value);
+int bytecode_new_constant(Bytecode *bc, Value value);
 void emit_byte(Bytecode *bc, uint8_t byte);
 void emit_op_const(Bytecode *bc, OpCode op, uint8_t const_index);
 

--- a/lexer.c
+++ b/lexer.c
@@ -53,6 +53,19 @@ Token *lex(const char *source, size_t *out_count) {
             add_token(&tokens,&count,&capacity,type,buf,line,tok_col);
             continue;
         }
+        if (c == '"') {
+            char buf[MAX_TOKEN_TEXT] = {0};
+            size_t len = 0;
+            i++; col++; // skip opening quote
+            while (source[i] && source[i] != '"' && len < MAX_TOKEN_TEXT-1) {
+                buf[len++] = source[i++];
+                col++;
+            }
+            if (source[i] == '"') { i++; col++; }
+            buf[len] = '\0';
+            add_token(&tokens, &count, &capacity, T_STRING, buf, line, tok_col);
+            continue;
+        }
         if (isdigit(c)) {
             char buf[MAX_TOKEN_TEXT]={0}; size_t len=0;
             while(isdigit(source[i])&&len<MAX_TOKEN_TEXT-1){ buf[len++]=source[i++]; col++; }

--- a/parser.c
+++ b/parser.c
@@ -152,7 +152,14 @@ static ASTNode *parse_primary(Parser *p) {
     Token *t = peek(p);
     if (match(p, T_NUMBER)) {
         ASTNode *n = ast_node_new(AST_LITERAL, t->line, t->column);
+        n->as.literal.is_string = 0;
         n->as.literal.value = atoi(t->text);
+        return n;
+    }
+    if (match(p, T_STRING)) {
+        ASTNode *n = ast_node_new(AST_LITERAL, t->line, t->column);
+        n->as.literal.is_string = 1;
+        n->as.literal.str = strdup(t->text);
         return n;
     }
     if (t->type == T_IDENTIFIER || t->type == T_PRINT) {

--- a/tokens.h
+++ b/tokens.h
@@ -44,7 +44,8 @@ typedef enum {
 
     // Identifiers and literals
     T_IDENTIFIER, // variable or function names (e.g., $x, foo)
-    T_NUMBER      // numeric literals (e.g., 123)
+    T_NUMBER,     // numeric literals (e.g., 123)
+    T_STRING      // string literals (e.g., "hello")
 } TokenType;
 
 typedef struct {


### PR DESCRIPTION
## Summary
- add `T_STRING` token type
- lex string literals
- extend AST literals to handle strings
- handle string literals in code generation
- update VM to store typed `Value` objects and print strings
- fix jump offset calculation for loops

## Testing
- `make`
- `./bin/phpc /tmp/test.phpc` → `hello`
- `./bin/phpc /tmp/simple.phpc` → `012`

------
https://chatgpt.com/codex/tasks/task_e_6878d3d772b08322a4db371b14f47955